### PR TITLE
Draft for MKDocs based documentation for SUQ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci 
+on:
+  push:
+    branches:
+      - master 
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: pip install mkdocstrings-python 
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Docs
+
+on:
+  push:
+    branches: [ main ]          # rebuild on every push to main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:            # manual “Run workflow” button
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install MkDocs & plugins
+        run: |
+          pip install mkdocs-material "mkdocstrings[python]"
+
+      - name: Build & deploy to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # built-in
+        run: |
+          mkdocs gh-deploy --force --clean --verbose

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,3 @@
-# Welcome to MkDocs
+# Introduction
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
-
-## Commands
-
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
-
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+Documentation for SUQ: Streamlined Uncertainty Quantification.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,11 @@
+SUQ API Documentation
+
+# Base Functions
+::: suq.base_suq
+
+# MLP Functions with Diagonal Covariance
+::: suq.diag_suq_mlp
+
+# Transformer Functions with Diagonal Covariance
+::: suq.diag_suq_transformer
+

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,11 +1,11 @@
-SUQ API Documentation
+# SUQ Documentation
 
-# Base Functions
+## Base Functions
 ::: suq.base_suq
 
-# MLP Functions with Diagonal Covariance
+## MLP Functions with Diagonal Covariance
 ::: suq.diag_suq_mlp
 
-# Transformer Functions with Diagonal Covariance
-::: suq.diag_suq_transformer
 
+## Transformer Functions with Diagonal Covariance
+::: suq.diag_suq_transformer

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,29 @@
+site_name: SUQ.jl
+site_url: https://AaltoML.github.io/SUQ # change this
+
+repo_url: https://github.com/AaltoML/SUQ
+repo_name: AaltoML/SUQ
+
+theme:
+  name: material
+  language: en
+  icon:
+    repo: fontawesome/brands/github  # optional, for GitHub icon
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+
+plugins:
+  - search
+  - mkdocstrings
+
+nav:
+  - Home: index.md
+  - API Reference: reference.md
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
-site_name: SUQ.jl
+site_name: SUQ.py
 site_url: https://AaltoML.github.io/SUQ # change this
 
 repo_url: https://github.com/AaltoML/SUQ
 repo_name: AaltoML/SUQ
 
-theme:
+theme: 
   name: material
   language: en
   icon:
@@ -21,7 +21,17 @@ markdown_extensions:
 
 plugins:
   - search
-  - mkdocstrings
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_root_heading: false
+            show_root_members: true
+            show_root_toc_entry: false
+            heading_level: 3
+            group_by_category: true
+            show_category_heading: true
+            members_order: source
 
 nav:
   - Home: index.md

--- a/suq/base_suq.py
+++ b/suq/base_suq.py
@@ -38,12 +38,12 @@ class SUQ_Base(nn.Module):
         """
         Applies a probit approximation to compute class probabilities from the latent Gaussian distribution.
         
-        Inputs:
-            out_mean (Tensor): Latent function mean, shape [B, C]
-            out_var (Tensor): Latent function variance, shape [B, C] or [B, C, C]
+        Args:
+            out_mean (Tensor): Latent function mean, shape [B, num_classes]
+            out_var (Tensor): Latent function variance, shape [B, num_classes] or [B, num_classes, num_classes]
 
-        Outputs:
-            posterior_predict_mean (Tensor): Predicted class probabilities, shape [B, C]
+        Returns:
+            posterior_predict_mean (Tensor): Predicted class probabilities, shape [B, num_classes]
         """
 
         if out_var.dim() == 3:
@@ -58,14 +58,14 @@ class SUQ_Base(nn.Module):
         """
         Fits the scale factor for predictive variance using negative log predictive density (NLPD).
 
-        Inputs:
+        Args:
             data_loader (DataLoader): Dataloader containing (input, target) pairs
             n_epoches (int): Number of epochs for optimization
             lr (float): Learning rate for scale optimizer
             speedup (bool): If True (classification only), caches forward pass outputs to accelerate fitting
             verbose (bool): If True, prints NLPD at each epoch
 
-        Outputs:
+        Returns:
             total_train_nlpd (List[float]): Average NLPD per epoch over training data
         """
         print("fit scale factor")

--- a/suq/base_suq.py
+++ b/suq/base_suq.py
@@ -15,13 +15,14 @@ class SUQ_Base(nn.Module):
     Base class for SUQ models.
 
     Provides core functionality for:
+
     - Managing likelihood type (regression or classification)
     - Probit-based approximation for classification
     - NLPD-based fitting of the scale factor
 
-    Inputs:
-        likelihood (str): Either 'classification' or 'regression'
-        scale_init (float): Initial value for the scale factor parameter
+    Args:
+        likelihood (str): Either `classification` or `regression`.
+        scale_init (float): Initial value for the scale factor parameter.
     """
     
     def __init__(self, likelihood, scale_init):

--- a/suq/diag_suq_mlp.py
+++ b/suq/diag_suq_mlp.py
@@ -9,18 +9,26 @@ from suq.base_suq import SUQ_Base
 
 def forward_aW_diag(a_mean, a_var, weight, bias, w_var, b_var):
     """
-    compute mean and covariance of h = a @ W^T + b when posterior has diag covariance
+    Compute mean and covariance of `h = a @ W^T + b` when the posterior has diagonal covariance.
     
-    ----- Input -----
-    a_mean: [N, D_in] mean(a)
-    a_var: [N, D_in] a_var[i] = var(a_i)
-    weight: [D_out, D_in] W
-    bias: [D_out, ] b
-    b_var: [D_out, ] b_var[k]: var(b_k)
-    w_var: [D_out, D_in] w_cov[k][i]: var(w_ki)
-    ----- Output -----
-    h_mean: [N, D_out]
-    h_var: [N, D_out] h_var[k] = var(h_k)
+    Args:
+        a_mean: Mean of `a` assuming `a` is `[N, D_in]`.
+        a_var: [N, D_in] 
+                Element wise variance of `a`
+        weight: [D_out, D_in]
+                Weights of the layer.
+        bias: [D_out, ]
+                Bias of the layer.
+        b_var: [D_out, ] 
+                Element wise variance of the bias.
+        w_var: [D_out, D_in]
+                Element wise variance of the weights.
+    
+    Returns: 
+        h_mean: [N, D_out]
+                Mean of the pre-activations.
+        h_var: [N, D_out]
+                Element wise variance of the pre-activations.
     """
     
     # calculate mean(h)

--- a/suq/diag_suq_mlp.py
+++ b/suq/diag_suq_mlp.py
@@ -9,26 +9,19 @@ from suq.base_suq import SUQ_Base
 
 def forward_aW_diag(a_mean, a_var, weight, bias, w_var, b_var):
     """
-    Compute mean and covariance of `h = a @ W^T + b` when the posterior has diagonal covariance.
+    Compute the mean and element-wise variance of `h = a @ W^T + b` when the posterior has diagonal covariance.
     
     Args:
-        a_mean: Mean of `a` assuming `a` is `[N, D_in]`.
-        a_var: [N, D_in] 
-                Element wise variance of `a`
-        weight: [D_out, D_in]
-                Weights of the layer.
-        bias: [D_out, ]
-                Bias of the layer.
-        b_var: [D_out, ] 
-                Element wise variance of the bias.
-        w_var: [D_out, D_in]
-                Element wise variance of the weights.
+        a_mean (Tensor): Mean of the input `a`. Shape: `[B, D_in]`.
+        a_var (Tensor): Variance of the input `a`. Shape: `[B, D_in] `
+        weight (Tensor): Mean of the weights `W`. Shape: `[D_out, D_in]`
+        bias (Tensor): Mean of the bias `b`. Shape: `[D_out, ]`
+        b_var (Tensor): Element-wise variance of the bias `b`. Shape: `[D_out, ]`
+        w_var (Tensor): Element-wise variance of the weights `W`. Shape: `[D_out, D_in]`
     
     Returns: 
-        h_mean: [N, D_out]
-                Mean of the pre-activations.
-        h_var: [N, D_out]
-                Element wise variance of the pre-activations.
+        h_mean (Tensor): Mean of the pre-activations `h`. Shape: `[B, D_out]`
+        h_var (Tensor): Element-wise variance of the pre-activations `h`. Shape: `[B, D_out]`
     """
     
     # calculate mean(h)
@@ -42,19 +35,20 @@ def forward_aW_diag(a_mean, a_var, weight, bias, w_var, b_var):
 
 
 def forward_activation_implicit_diag(activation_func, h_mean, h_var):
+    
     """
-    given h ~ N(h_mean, h_cov), g(·), where h_cov is a diagonal matrix,
-    approximate the distribution of a = g(h) as 
-    a ~ N(g(h_mean), g'(h_mean)^T h_var g'(h_mean))
-    
-    input
-    activation_func: g(·)
-    h_mean: [N, D]
-    h_var: [N, D], h_var[i] = var(h_i)
-    
-    output
-    a_mean: [N, D]
-    a_var: [N, D]
+    Approximate the distribution of `a = g(h)` given `h ~ N(h_mean, h_var)`, where `h_var` 
+    is the element-wise variance of pre-activation `h`.
+    Uses a first-order Taylor expansion: `a ~ N(g(h_mean), g'(h_mean)^T @ h_var @ g'(h_mean))`.
+
+    Args:
+        activation_func (Callable): A PyTorch activation function `g(·)` (e.g. `nn.ReLU()`)
+        h_mean (Tensor): Mean of the pre-activations `h`. Shape: `[B, D]`
+        h_var (Tensor): Element-wise variance of the pre-activations `h`. Shape: `[B, D]`
+
+    Returns:
+        a_mean (Tensor): Mean of the activations `a`. Shape: `[B, D]`
+        a_var (Tensor): Element-wise variance of the activations `a`. Shape: `[B, D]`
     """
 
     h_mean_grad = h_mean.detach().clone().requires_grad_()
@@ -69,18 +63,19 @@ def forward_activation_implicit_diag(activation_func, h_mean, h_var):
     return a_mean.detach(), a_var
 
 def forward_batch_norm_diag(h_var, bn_weight, bn_running_var, bn_eps):
+    
     """
-    Pass a distribution with diagonal covariance through BatchNorm layer
-    
-    Input
-        h_mean: mean of input distribution [B, D]
-        h_var: variance of input distribution [B, D]
-        bn_weight: batch norm scale factor [D, ]
-        bn_running_var: batch norm running variance [D, ]
-        bn_eps: batch norm eps
-    
-    Output
-        output_var [B, T, D]
+    Compute the output variance when a distribution `h ~ N(h_mean, h_var)`
+    is passed through a BatchNorm layer.
+
+    Args:
+        h_var (Tensor): Element-wise variance of the input `h`. Shape: `[B, D]`.
+        bn_weight (Tensor): Batch normalization scale factor (gamma). Shape: `[D,]`.
+        bn_running_var (Tensor): Running variance used in batch normalization. Shape: `[D,]`.
+        bn_eps (float): Small constant added to the denominator for numerical stability.
+
+    Returns:
+        output_var (Tensor): Element-wise variance of the output after batch normalization. Shape: `[B, D]`.
     """
 
     scale_factor = (1 / (bn_running_var.reshape(1, -1) + bn_eps)) * bn_weight.reshape(1, -1) **2 # [B, D]
@@ -94,10 +89,10 @@ class SUQ_Linear_Diag(nn.Module):
     
     Wraps a standard `nn.Linear` layer and applies closed-form mean and variance propagation. See the SUQ paper for theoretical background and assumptions.
 
-    Inputs:
-        org_linear (nn.Linear): The original linear layer to wrap
-        w_var (Tensor): Weight variances, shape [D_out, D_in]
-        b_var (Tensor): Bias variances, shape [D_out]
+    Args:
+        org_linear (nn.Linear): The original linear layer to wrap      
+        w_var (Tensor): Element-wise variance of the weights `W`. Shape: `[D_out, D_in]`
+        b_var (Tensor): Element-wise variance of the bias `b`. Shape: `[D_out, ]`
     """
     def __init__(self, org_linear, w_var, b_var):
         super().__init__()
@@ -109,13 +104,14 @@ class SUQ_Linear_Diag(nn.Module):
     
     def forward(self, a_mean, a_var): 
         """
-        Inputs:
-            a_mean (Tensor): Input mean, shape [N, D_in]
-            a_var (Tensor): Input variance, shape [N, D_in]
+        Forward pass with uncertainty propagation through a SUQ linear layer.
+        
+        Args:
+            a_mean (Tensor): Input mean. Shape: `[B, D_in]`
+            a_var (Tensor): Input element-wise variance. Shape: `[B, D_in]`
 
-        Outputs:
-            h_mean (Tensor): Output mean, shape [N, D_out]
-            h_var (Tensor): Output variance, shape [N, D_out]
+        Returns:
+            h_mean (Tensor): Output mean. Shape: `[B, D_out]`
         """
         
         if a_var == None:
@@ -131,8 +127,8 @@ class SUQ_Activation_Diag(nn.Module):
 
     Wraps a standard activation function and applies a first-order approximation to propagate input variance through the nonlinearity. See the SUQ paper for theoretical background and assumptions.
 
-    Inputs:
-        afun (Callable): A PyTorch activation function (e.g. nn.ReLU())
+    Args:
+        afun (Callable): A PyTorch activation function (e.g. `nn.ReLU()`)
     """
     
     def __init__(self, afun):        
@@ -141,13 +137,15 @@ class SUQ_Activation_Diag(nn.Module):
     
     def forward(self, h_mean, h_var):
         """
-        Inputs:
-            h_mean (Tensor): Input mean before activation, shape [N, D]
-            h_var (Tensor): Input variance before activation, shape [N, D]
+        Forward pass with uncertainty propagation through a SUQ activation layer.
+        
+        Args:
+            h_mean (Tensor): Mean of the pre-activations `h`. Shape: `[B, D]`
+            h_var (Tensor): Element-wise variance of the pre-activation `h`. Shape: `[B, D]`
 
-        Outputs:
-            a_mean (Tensor): Activated output mean, shape [N, D]
-            a_var (Tensor): Approximated output variance, shape [N, D]
+        Returns:
+            a_mean (Tensor): Mean of the activation `a`. Shape: [B, D]
+            a_var (Tensor): Element-wise variance of the activation `a`. Shape: `[B, D]`
         """
         a_mean, a_var = forward_activation_implicit_diag(self.afun, h_mean, h_var)
         return a_mean, a_var
@@ -158,7 +156,7 @@ class SUQ_BatchNorm_Diag(nn.Module):
 
     Wraps `nn.BatchNorm1d` and adjusts input variance using batch normalization statistics and scale parameters. See the SUQ paper for theoretical background and assumptions.
 
-    Inputs:
+    Args:
         BatchNorm (nn.BatchNorm1d): The original batch norm layer
     """
     
@@ -169,13 +167,15 @@ class SUQ_BatchNorm_Diag(nn.Module):
     
     def forward(self, x_mean, x_var):
         """
-        Inputs:
-            x_mean (Tensor): Input mean, shape [B, D]
-            x_var (Tensor): Input variance, shape [B, D]
+        Forward pass with uncertainty propagation through a SUQ BatchNorm layer.
+        
+        Args:
+            x_mean (Tensor): Input mean. Shape: [B, D]
+            x_var (Tensor): Input element-wise variance. Shape: [B, D]
 
-        Outputs:
-            out_mean (Tensor): Output mean after batch normalization, shape [B, D]
-            out_var (Tensor): Output variance after batch normalization, shape [B, D]
+        Returns:
+            out_mean (Tensor): Output mean after batch normalization. Shape: [B, D]
+            out_var (Tensor): Output element-wise variance after batch normalization. Shape: [B, D]
         """
         
         with torch.no_grad():
@@ -198,7 +198,7 @@ class SUQ_MLP_Diag(SUQ_Base):
         - For regression, this is the full model (including final output layer).
         - For classification, exclude the softmax layer and pass only the logit-producing part.
 
-    Inputs:
+    Args:
         org_model (nn.Module): The original MLP model to convert
         posterior_variance (Tensor): Flattened posterior variance vector
         likelihood (str): Either 'classification' or 'regression'
@@ -218,13 +218,13 @@ class SUQ_MLP_Diag(SUQ_Base):
 
         Traverses the model layer by layer, propagating mean and variance through each SUQ-wrapped layer.
 
-        Inputs:
-            data (Tensor): Input data, shape [B, D]
-            out_var (Tensor or None): Optional input variance, shape [B, D]
+        Args:
+            data (Tensor): Input data. Shape: [B, D_in]
+            out_var (Tensor or None): Optional input variance. Shape: [B, D_in]
 
-        Outputs:
-            out_mean (Tensor): Output mean after final layer, shape [B, D_out]
-            out_var (Tensor): Output variance after final layer, shape [B, D_out]
+        Returns:
+            out_mean (Tensor): Output mean after final layer. Shape: [B, D_out]
+            out_var (Tensor): Output element-wise variance after final layer. Shape: [B, D_out]
         """
         
         out_mean = data
@@ -245,14 +245,14 @@ class SUQ_MLP_Diag(SUQ_Base):
         For classification, use probit-approximation.
         For regression, returns the latent mean and total predictive variance.
 
-        Inputs:
-            data (Tensor): Input data, shape [B, D]
+        Args:
+            data (Tensor): Input data. Shape: [B, D]
 
-        Outputs:
+        Returns:
             If classification:
-                Tensor: Class probabilities, shape [B, num_classes]
+                Tensor: Class probabilities. Shape: [B, num_classes]
             If regression:
-                Tuple[Tensor, Tensor]: Output mean and total variance, shape [B, D_out]
+                Tuple[Tensor, Tensor]: Output mean and element-wise variance. Shape: [B, D_out]
         """
         
         out_mean, out_var = self.forward_latent(data)
@@ -270,7 +270,7 @@ class SUQ_MLP_Diag(SUQ_Base):
 
         Each layer is replaced with its corresponding SUQ module (e.g. linear, activation, batchnorm), using the provided flattened posterior variance vector.
 
-        Inputs:
+        Args:
             org_model (nn.Module): The original model to convert (latent function only)
             posterior_variance (Tensor): Flattened posterior variance for Bayesian parameters
         """
@@ -286,11 +286,6 @@ class SUQ_MLP_Diag(SUQ_Base):
                 num_weight_param = D_out * D_in
                 
                 covariance_block = posterior_variance[loc : loc + num_param]
-                
-                """
-                w_var: [D_out, D_in], w_var[k][i] = var(w_ki)
-                b_var: [D_out, ] b_var[k]: var(b_k)
-                """        
                 
                 b_var = torch.zeros_like(layer.bias.data).to(layer.bias.data.device)
                 w_var = torch.zeros_like(layer.weight.data).to(layer.bias.data.device)


### PR DESCRIPTION
This PR adds documentation using MKDocs (https://www.mkdocs.org/getting-started/). 

How to use it locally:
1. Install mkdocs with `pip install mkdocs-material` and `pip install mkdocstrings-python`.
2. Run local server `mkdocs serve`

Todo list:
- [x] Add continuous integration (@trappmartin will add this)
- [x] Fix Python inline documentation and make it consistent with the expected format.